### PR TITLE
replace deprecated java docker image by openjdk

### DIFF
--- a/almundo/java/8-1.0.0/Dockerfile
+++ b/almundo/java/8-1.0.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM openjdk:8
 MAINTAINER Franco Morinigo <franco.morinigo@almundo.com>
 
 # Install jq


### PR DESCRIPTION
The docker [docker java image](https://hub.docker.com/_/java/) is deprecated in favor of the openjdk image.

Extracted from the page:

> This image is officially deprecated in favor of the openjdk image, and will receive no further updates after 2016-12-31 (Dec 31, 2016). Please adjust your usage accordingly.
